### PR TITLE
Unify the build process on all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GO_BUILD_FLAGS = -v
 GO_BUILD_LDFLAGS = -X main.version=$(VERSION)
 GQL_GEN = $(GO_PATH)/bin/gqlgen
 
-PLATFORMS := linux darwin
+PLATFORMS := linux darwin windows
 os = $(word 1, $@)
 ARCH = amd64
 
@@ -79,7 +79,7 @@ clean: tools
 	-rm -rf coverage.txt
 
 .PHONY: build
-build: deps linux darwin
+build: deps linux darwin windows
 
 .PHONY: check
 check: clean

--- a/plugins/queue/queues.go
+++ b/plugins/queue/queues.go
@@ -15,19 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build !windows
+
 package queue
 
 import (
-	"reflect"
-
-	"github.com/apache/skywalking-satellite/internal/pkg/plugin"
 	"github.com/apache/skywalking-satellite/plugins/queue/api"
+	"github.com/apache/skywalking-satellite/plugins/queue/memory"
+	"github.com/apache/skywalking-satellite/plugins/queue/mmap"
 )
 
-// RegisterQueuePlugins register the used queue plugins.
-func RegisterQueuePlugins() {
-	plugin.RegisterPluginCategory(reflect.TypeOf((*api.Queue)(nil)).Elem())
-	for _, q := range queues {
-		plugin.RegisterPlugin(q)
-	}
+var queues = []api.Queue{
+	// Please register the queue plugins available on Linux, MacOS here.
+	new(memory.Queue),
+	new(mmap.Queue),
 }

--- a/plugins/queue/queues_windows.go
+++ b/plugins/queue/queues_windows.go
@@ -15,19 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build windows
+
 package queue
 
 import (
-	"reflect"
-
-	"github.com/apache/skywalking-satellite/internal/pkg/plugin"
 	"github.com/apache/skywalking-satellite/plugins/queue/api"
+	"github.com/apache/skywalking-satellite/plugins/queue/memory"
 )
 
-// RegisterQueuePlugins register the used queue plugins.
-func RegisterQueuePlugins() {
-	plugin.RegisterPluginCategory(reflect.TypeOf((*api.Queue)(nil)).Elem())
-	for _, q := range queues {
-		plugin.RegisterPlugin(q)
-	}
+var queues = []api.Queue{
+	// Please register the queue plugins available on Windows platform here.
+	new(memory.Queue),
 }


### PR DESCRIPTION
Because some plugins are not available on Windows, those plugins are separated in individual package and are only built on available platforms, using `+build` flag.