### PR TITLE
Update H2 Database to 2.0.206 to address CVE-2021-42392.

### DIFF
--- a/test/e2e/base/provider/pom.xml
+++ b/test/e2e/base/provider/pom.xml
@@ -54,7 +54,7 @@
         <jupeter.version>5.6.0</jupeter.version>
         <jackson.version>2.9.7</jackson.version>
         <guava.version>28.2-jre</guava.version>
-        <h2.version>1.4.199</h2.version>
+        <h2.version>2.0.206</h2.version>
         <mysql.version>8.0.13</mysql.version>
         <lombok.version>1.18.20</lombok.version>
         <kafka-clients.version>2.4.1</kafka-clients.version>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392