### PR TITLE
Add the compat protocol receiver for the old version of agents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 1.0.0
 ------------------
 #### Features
+* Add the compat protocol receiver for the old version of agents.
 
 #### Bug Fixes
 

--- a/dist/LICENSE
+++ b/dist/LICENSE
@@ -500,7 +500,7 @@ The text of each license is also included at licenses/license-[project].txt.
     gonum.org-v1-gonum v0.6.0 https://gonum.org/v1/gonum BSD-3-Clause
     gonum.org-v1-netlib v0.0.0 https://gonum.org/v1/netlib BSD-3-Clause
     google.golang.org-api v0.32.0 https://google.golang.org/api BSD-3-Clause
-    google.golang.org-protobuf v1.27.1 https://google.golang.org/protobuf BSD-3-Clause
+    google.golang.org-protobuf v1.28.0 https://google.golang.org/protobuf BSD-3-Clause
     gopkg.in-airbrake-gobrake.v2 v2.0.9 https://gopkg.in/airbrake/gobrake.v2 BSD-3-Clause
     gopkg.in-cheggaaa-pb.v1 v1.0.25 https://gopkg.in/cheggaaa/pb.v1 BSD-3-Clause
     gopkg.in-errgo.v2 v2.1.0 https://gopkg.in/errgo.v2 BSD-3-Clause

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,11 @@ require (
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/mod v0.4.2
 	google.golang.org/grpc v1.44.0
-	google.golang.org/protobuf v1.27.1
+	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.20.6
-	skywalking.apache.org/repo/goapi v0.0.0-20211130045256-aee6db90e633
+	skywalking.apache.org/repo/goapi v0.0.0-20220402141816-76988aaeab46
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1275,7 +1275,7 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1390,7 +1390,7 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1604,8 +1604,9 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1721,6 +1722,6 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-skywalking.apache.org/repo/goapi v0.0.0-20211130045256-aee6db90e633 h1:sneWCKi5BckD4crMDSU4IjFymZjYGsRdHE1O/B9wugA=
-skywalking.apache.org/repo/goapi v0.0.0-20211130045256-aee6db90e633/go.mod h1:4KrWd+Oi4lkB+PtxZgIlf+3T6EECPru4fOWNMEHjxRk=
+skywalking.apache.org/repo/goapi v0.0.0-20220402141816-76988aaeab46 h1:c06FRvU+wwM0+Uk6EDbVT1rN8qp+YqHHCdW7CrLnDOg=
+skywalking.apache.org/repo/goapi v0.0.0-20220402141816-76988aaeab46/go.mod h1:uWwwvhcwe2MD/nJCg0c1EE/eL6KzaBosLHDfMFoEJ30=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/plugins/receiver/grpc/nativejvm/jvm_report_service_compact.go
+++ b/plugins/receiver/grpc/nativejvm/jvm_report_service_compact.go
@@ -1,0 +1,35 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package nativelog
+
+import (
+	"context"
+
+	common "skywalking.apache.org/repo/goapi/collect/common/v3"
+	agent "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	agent_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
+)
+
+type JVMReportServiceCompat struct {
+	reportService *JVMReportService
+	agent_compat.UnimplementedJVMMetricReportServiceServer
+}
+
+func (j *JVMReportServiceCompat) Collect(ctx context.Context, jvm *agent.JVMMetricCollection) (*common.Commands, error) {
+	return j.reportService.Collect(ctx, jvm)
+}

--- a/plugins/receiver/grpc/nativejvm/receiver.go
+++ b/plugins/receiver/grpc/nativejvm/receiver.go
@@ -19,6 +19,7 @@ package nativelog
 
 import (
 	agent "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	agent_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
 	v1 "skywalking.apache.org/repo/goapi/satellite/data/v1"
 
 	"github.com/apache/skywalking-satellite/internal/pkg/config"
@@ -60,6 +61,7 @@ func (r *Receiver) RegisterHandler(server interface{}) {
 	r.CommonGRPCReceiverFields = *grpcreceiver.InitCommonGRPCReceiverFields(server)
 	r.service = &JVMReportService{receiveChannel: r.OutputChannel}
 	agent.RegisterJVMMetricReportServiceServer(r.Server, r.service)
+	agent_compat.RegisterJVMMetricReportServiceServer(r.Server, &JVMReportServiceCompat{reportService: r.service})
 }
 
 func (r *Receiver) RegisterSyncInvoker(_ module.SyncInvoker) {

--- a/plugins/receiver/grpc/nativejvm/receiver_test.go
+++ b/plugins/receiver/grpc/nativejvm/receiver_test.go
@@ -76,9 +76,8 @@ func initData() *agent.JVMMetricCollection {
 				},
 				Gc: []*agent.GC{
 					{
-						Phrase: 2,
-						Count:  3,
-						Time:   202106111010,
+						Count: 3,
+						Time:  202106111010,
 					},
 				},
 				Thread: &agent.Thread{

--- a/plugins/receiver/grpc/nativemanagement/management_report_service_compat.go
+++ b/plugins/receiver/grpc/nativemanagement/management_report_service_compat.go
@@ -1,0 +1,39 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package nativemanagement
+
+import (
+	"context"
+
+	common "skywalking.apache.org/repo/goapi/collect/common/v3"
+	management "skywalking.apache.org/repo/goapi/collect/management/v3"
+	management_compat "skywalking.apache.org/repo/goapi/collect/management/v3/compat"
+)
+
+type ManagementReportServiceCompat struct {
+	reportService *ManagementReportService
+	management_compat.UnimplementedManagementServiceServer
+}
+
+func (m *ManagementReportServiceCompat) ReportInstanceProperties(ctx context.Context, in *management.InstanceProperties) (*common.Commands, error) {
+	return m.reportService.ReportInstanceProperties(ctx, in)
+}
+
+func (m *ManagementReportServiceCompat) KeepAlive(ctx context.Context, in *management.InstancePingPkg) (*common.Commands, error) {
+	return m.reportService.KeepAlive(ctx, in)
+}

--- a/plugins/receiver/grpc/nativemanagement/receiver.go
+++ b/plugins/receiver/grpc/nativemanagement/receiver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/skywalking-satellite/plugins/receiver/grpc"
 
 	v3 "skywalking.apache.org/repo/goapi/collect/management/v3"
+	v3_compat "skywalking.apache.org/repo/goapi/collect/management/v3/compat"
 	v1 "skywalking.apache.org/repo/goapi/satellite/data/v1"
 )
 
@@ -60,6 +61,7 @@ func (r *Receiver) RegisterHandler(server interface{}) {
 	r.CommonGRPCReceiverFields = *grpc.InitCommonGRPCReceiverFields(server)
 	r.service = &ManagementReportService{receiveChannel: r.OutputChannel}
 	v3.RegisterManagementServiceServer(r.Server, r.service)
+	v3_compat.RegisterManagementServiceServer(r.Server, &ManagementReportServiceCompat{reportService: r.service})
 }
 
 func (r *Receiver) RegisterSyncInvoker(_ module.SyncInvoker) {

--- a/plugins/receiver/grpc/nativemeter/meter_service_compat.go
+++ b/plugins/receiver/grpc/nativemeter/meter_service_compat.go
@@ -1,0 +1,31 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package nativemeter
+
+import (
+	agent_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
+)
+
+type MeterServiceCompat struct {
+	reportService *MeterService
+	agent_compat.UnimplementedMeterReportServiceServer
+}
+
+func (m *MeterServiceCompat) Collect(stream agent_compat.MeterReportService_CollectServer) error {
+	return m.reportService.Collect(stream)
+}

--- a/plugins/receiver/grpc/nativemeter/receiver.go
+++ b/plugins/receiver/grpc/nativemeter/receiver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/skywalking-satellite/plugins/receiver/grpc"
 
 	meter "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	meter_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
 	v1 "skywalking.apache.org/repo/goapi/satellite/data/v1"
 )
 
@@ -60,6 +61,7 @@ func (r *Receiver) RegisterHandler(server interface{}) {
 	r.CommonGRPCReceiverFields = *grpc.InitCommonGRPCReceiverFields(server)
 	r.service = &MeterService{receiveChannel: r.OutputChannel}
 	meter.RegisterMeterReportServiceServer(r.Server, r.service)
+	meter_compat.RegisterMeterReportServiceServer(r.Server, &MeterServiceCompat{reportService: r.service})
 }
 
 func (r *Receiver) RegisterSyncInvoker(_ module.SyncInvoker) {

--- a/plugins/receiver/grpc/nativeprofile/profile_service_compat.go
+++ b/plugins/receiver/grpc/nativeprofile/profile_service_compat.go
@@ -1,0 +1,43 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package nativeprofile
+
+import (
+	"context"
+
+	common "skywalking.apache.org/repo/goapi/collect/common/v3"
+	profile "skywalking.apache.org/repo/goapi/collect/language/profile/v3"
+	profile_compat "skywalking.apache.org/repo/goapi/collect/language/profile/v3/compat"
+)
+
+type ProfileServiceCompat struct {
+	reportService *ProfileService
+	profile_compat.UnimplementedProfileTaskServer
+}
+
+func (p *ProfileServiceCompat) GetProfileTaskCommands(ctx context.Context, q *profile.ProfileTaskCommandQuery) (*common.Commands, error) {
+	return p.reportService.GetProfileTaskCommands(ctx, q)
+}
+
+func (p *ProfileServiceCompat) CollectSnapshot(stream profile_compat.ProfileTask_CollectSnapshotServer) error {
+	return p.reportService.CollectSnapshot(stream)
+}
+
+func (p *ProfileServiceCompat) ReportTaskFinish(ctx context.Context, report *profile.ProfileTaskFinishReport) (*common.Commands, error) {
+	return p.reportService.ReportTaskFinish(ctx, report)
+}

--- a/plugins/receiver/grpc/nativeprofile/receiver.go
+++ b/plugins/receiver/grpc/nativeprofile/receiver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/skywalking-satellite/plugins/receiver/grpc"
 
 	v3 "skywalking.apache.org/repo/goapi/collect/language/profile/v3"
+	v3_compat "skywalking.apache.org/repo/goapi/collect/language/profile/v3/compat"
 	v1 "skywalking.apache.org/repo/goapi/satellite/data/v1"
 )
 
@@ -60,6 +61,7 @@ func (r *Receiver) RegisterHandler(server interface{}) {
 	r.CommonGRPCReceiverFields = *grpc.InitCommonGRPCReceiverFields(server)
 	r.service = &ProfileService{receiveChannel: r.OutputChannel}
 	v3.RegisterProfileTaskServer(r.Server, r.service)
+	v3_compat.RegisterProfileTaskServer(r.Server, &ProfileServiceCompat{reportService: r.service})
 }
 
 func (r *Receiver) RegisterSyncInvoker(invoker module.SyncInvoker) {

--- a/plugins/receiver/grpc/nativetracing/receiver.go
+++ b/plugins/receiver/grpc/nativetracing/receiver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/skywalking-satellite/plugins/receiver/grpc"
 
 	v3 "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	v3_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
 	v1 "skywalking.apache.org/repo/goapi/satellite/data/v1"
 )
 
@@ -60,6 +61,7 @@ func (r *Receiver) RegisterHandler(server interface{}) {
 	r.CommonGRPCReceiverFields = *grpc.InitCommonGRPCReceiverFields(server)
 	r.service = &TraceSegmentReportService{receiveChannel: r.OutputChannel}
 	v3.RegisterTraceSegmentReportServiceServer(r.Server, r.service)
+	v3_compat.RegisterTraceSegmentReportServiceServer(r.Server, &TraceSegmentReportServiceCompat{reportService: r.service})
 }
 
 func (r *Receiver) RegisterSyncInvoker(_ module.SyncInvoker) {

--- a/plugins/receiver/grpc/nativetracing/tracing_report_service_compat.go
+++ b/plugins/receiver/grpc/nativetracing/tracing_report_service_compat.go
@@ -1,0 +1,39 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package nativetracing
+
+import (
+	"context"
+
+	common "skywalking.apache.org/repo/goapi/collect/common/v3"
+	agent "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
+	agent_compat "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat"
+)
+
+type TraceSegmentReportServiceCompat struct {
+	reportService *TraceSegmentReportService
+	agent_compat.UnimplementedTraceSegmentReportServiceServer
+}
+
+func (s *TraceSegmentReportServiceCompat) Collect(stream agent_compat.TraceSegmentReportService_CollectServer) error {
+	return s.reportService.Collect(stream)
+}
+
+func (s *TraceSegmentReportServiceCompat) CollectInSync(ctx context.Context, segments *agent.SegmentCollection) (*common.Commands, error) {
+	return s.reportService.CollectInSync(ctx, segments)
+}


### PR DESCRIPTION
Follow https://github.com/apache/skywalking/issues/8791, Enhance the receiver for the old agents. I will create other PR for the documentation which describes agent compatibility with the satellite. 