### PR TITLE
Fix Metadata lost in the Native Meter protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 * Add the compat protocol receiver for the old version of agents.
 
 #### Bug Fixes
+* Fix Metadata lost in the Native Meter protocol.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/115?closed=1)

--- a/plugins/forwarder/grpc/nativemeter/forwarder.go
+++ b/plugins/forwarder/grpc/nativemeter/forwarder.go
@@ -100,11 +100,12 @@ func (f *Forwarder) Forward(batch event.BatchEvents) error {
 	}()
 	oldTransformDataCount := 0
 	for _, e := range batch {
-		if data, ok := e.GetData().(*v1.SniffData_MeterCollection); ok {
+		switch data := e.GetData().(type) {
+		case *v1.SniffData_MeterCollection:
 			if err := f.handleMeterCollection(data, streamMap); err != nil {
 				return err
 			}
-		} else if _, ok := e.GetData().(*v1.SniffData_Meter); ok {
+		case *v1.SniffData_Meter:
 			oldTransformDataCount++
 		}
 	}

--- a/plugins/forwarder/grpc/nativemeter/forwarder.go
+++ b/plugins/forwarder/grpc/nativemeter/forwarder.go
@@ -98,20 +98,14 @@ func (f *Forwarder) Forward(batch event.BatchEvents) error {
 			}
 		}
 	}()
-	oldTransformDataCount := 0
 	for _, e := range batch {
-		switch data := e.GetData().(type) {
-		case *v1.SniffData_MeterCollection:
+		// Only handle the meter collection data from queue
+		// There could have error when using previously meter data(SniffData_Meter)
+		if data, ok := e.GetData().(*v1.SniffData_MeterCollection); ok {
 			if err := f.handleMeterCollection(data, streamMap); err != nil {
 				return err
 			}
-		case *v1.SniffData_Meter:
-			oldTransformDataCount++
 		}
-	}
-	if oldTransformDataCount > 0 {
-		log.Logger.Warnf("Found out transform data, old data would cause backend statistics error, so ignore them. "+
-			"total count: %d", oldTransformDataCount)
 	}
 	return nil
 }

--- a/plugins/receiver/grpc/nativemeter/receiver_test.go
+++ b/plugins/receiver/grpc/nativemeter/receiver_test.go
@@ -48,7 +48,7 @@ func TestReceiver_RegisterHandler(t *testing.T) {
 		}
 		return data.String()
 	}, func(data *v1.SniffData) string {
-		return data.GetMeter().String()
+		return data.GetMeterCollection().MeterData[0].String()
 	}, t)
 }
 


### PR DESCRIPTION
Package the data when receiving streaming meter data, and use `collectBatch` to send them.
Ignore the old transform data(if using the `mmap` queue), and log it to ignore them.