### PR TITLE
Downgrade unnecessary log level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,13 @@ Changes by Version
 ==================
 Release Notes.
 
-1.0.0
+1.1.0
 ------------------
 #### Features
-* Add the compat protocol receiver for the old version of agents.
-* Support transmit the native eBPF Process and Profiling protocol.
-* Change the name of plugin that is not well-named.
+* Downgrade unnecessary log level.
 
 #### Bug Fixes
-* Fix Metadata lost in the Native Meter protocol.
 
 #### Issues and PR
-- All issues are [here](https://github.com/apache/skywalking/milestone/115?closed=1)
-- All and pull requests are [here](https://github.com/apache/skywalking-satellite/pulls?q=is%3Apr+milestone%3A1.0.0+is%3Aclosed)
+- All issues are [here](https://github.com/apache/skywalking/milestone/137?closed=1)
+- All and pull requests are [here](https://github.com/apache/skywalking-satellite/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.1.0)

--- a/changes/changes-1.0.0.md
+++ b/changes/changes-1.0.0.md
@@ -1,0 +1,17 @@
+Changes by Version
+==================
+Release Notes.
+
+1.0.0
+------------------
+#### Features
+* Add the compat protocol receiver for the old version of agents.
+* Support transmit the native eBPF Process and Profiling protocol.
+* Change the name of plugin that is not well-named.
+
+#### Bug Fixes
+* Fix Metadata lost in the Native Meter protocol.
+
+#### Issues and PR
+- All issues are [here](https://github.com/apache/skywalking/milestone/115?closed=1)
+- All and pull requests are [here](https://github.com/apache/skywalking-satellite/pulls?q=is%3Apr+milestone%3A1.0.0+is%3Aclosed)

--- a/internal/satellite/module/sender/sender.go
+++ b/internal/satellite/module/sender/sender.go
@@ -227,7 +227,7 @@ func (s *Sender) consume(batch *buffer.BatchBuffer) {
 		"pipe":   s.config.PipeName,
 		"offset": batch.Last(),
 		"size":   batch.Len(),
-	}).Info("sender module is flushing a new batch buffer.")
+	}).Debugf("sender module is flushing a new batch buffer.")
 	var events = make(map[v1.SniffType]event.BatchEvents)
 	for i := 0; i < batch.Len(); i++ {
 		eventContext := batch.Buf()[i]

--- a/plugins/client/grpc/client.go
+++ b/plugins/client/grpc/client.go
@@ -171,3 +171,15 @@ type logrusGrpcLoggerV2 struct {
 func (l *logrusGrpcLoggerV2) V(level int) bool {
 	return l.Logger.IsLevelEnabled(logrus.Level(level))
 }
+
+func (l *logrusGrpcLoggerV2) Infof(format string, args ...interface{}) {
+	l.Debugf(format, args)
+}
+
+func (l *logrusGrpcLoggerV2) Info(args ...interface{}) {
+	l.Debug(args)
+}
+
+func (l *logrusGrpcLoggerV2) Infoln(args ...interface{}) {
+	l.Debugln(args)
+}


### PR DESCRIPTION
We have a lot of logs that don't need to be printed, change them to debug level.