### PR TITLE
Bump up libssl to fix CVE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,8 @@ RUN mv /src/bin/skywalking-satellite-${VERSION}-linux-amd64 /src/bin/skywalking-
 
 FROM debian
 
+RUN apt update && apt install -y libssl-dev
+
 VOLUME /skywalking/configs
 
 WORKDIR /skywalking


### PR DESCRIPTION
@mrproliu I think we don't need to use the base image `debian` , can we use something like `alpine`?