### PR TITLE
Build Docker multi-arch without attestation manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ define DOCKER_RULE
 		--no-cache --build-arg VERSION=$(VERSION) \
 		-t $(HUB)/skywalking-satellite:v$(VERSION) \
 		-f docker/Dockerfile \
+                --provenance=false \
 		.
 	docker buildx rm skywalking_satellite || true
 endef


### PR DESCRIPTION

<img width="772" alt="image" src="https://github.com/apache/skywalking-satellite/assets/15965696/8ad54c88-1e09-4c23-87cc-78efb5729eaa">


We have `unknown/unknown` because of https://github.com/docker/buildx/issues/1507