### PR TITLE
cves: bump musl to fix CVE-2026-6042 and CVE-2026-40200

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,9 @@ RUN mv /src/bin/skywalking-satellite-${VERSION}-linux-${TARGETARCH} /src/bin/sky
 
 FROM alpine:3.23
 
+# Upgrade all packages to pick up latest security fixes, including:
+# - CVE-2026-6042: musl iconv GB18030 algorithmic inefficiency
+# - CVE-2026-40200: musl stack-based memory corruption in sorting
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
     apk add --no-cache ca-certificates


### PR DESCRIPTION
## CVEs Fixed

| Severity | CVE ID | Component | Fix |
|----------|--------|-----------|-----|
| UNKNOWN | CVE-2026-6042 | musl (Alpine 3.23) | apk upgrade picks up musl ≥ 1.2.5-r22 |
| LOW | CVE-2026-40200 | musl (Alpine 3.23) | apk upgrade picks up musl ≥ 1.2.5-r23 |

## Summary

The Dockerfile already runs `apk update && apk upgrade` before `apk add`, which ensures all Alpine packages are upgraded to latest. However, the current published image (`v6f0e3dead129`) was built on 2026-04-02 when the musl fixes were not yet available in Alpine 3.23 repos:

- CVE-2026-6042 is fixed in musl `1.2.5-r22` for Alpine 3.23 (released after 2026-04-02)
- CVE-2026-40200 is fixed in musl `1.2.5-r23` for Alpine 3.23 (released after 2026-04-02)

This commit adds documentation comments to the Dockerfile to explicitly record the CVEs being addressed, and triggers a fresh build that will pull `musl 1.2.5-r23` (the latest Alpine 3.23 musl as of 2026-04-10).

## References
- Closes https://github.com/tetrateio/tetrate/issues/28728
- Closes https://github.com/tetrateio/tetrate/issues/28608