### PR TITLE
cves: bump Go to 1.25.9, pin openssl 3.3.7 (CVE-2026-32282, CVE-2026-28390, CVE-2026-28388)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.8 AS build
+FROM golang:1.25.9 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH
@@ -32,7 +32,7 @@ FROM alpine:3.23
 
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates
+    apk add --no-cache ca-certificates libssl3>=3.3.7-r0 libcrypto3>=3.3.7-r0
 
 VOLUME /skywalking/configs
 


### PR DESCRIPTION
## CVEs Fixed

| CVE | Severity | Component | Fix |
|-----|----------|-----------|-----|
| CVE-2026-32282 | High | stdlib (Go) | Bump Go base image from 1.25.8 → 1.25.9 |
| CVE-2026-28390 | High | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` in alpine stage |
| CVE-2026-28388 | High | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` in alpine stage |
| CVE-2026-31790 | Medium | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` in alpine stage |
| CVE-2026-28387 | Medium | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` in alpine stage |

## Changes

- `docker/Dockerfile`: Bumped `golang:1.25.8` → `golang:1.25.9` in the build stage
- `docker/Dockerfile`: Added explicit version pins `libssl3>=3.3.7-r0 libcrypto3>=3.3.7-r0` to the `apk add` command in the alpine runtime stage to ensure openssl 3.3.7-r0 (or newer) is installed, addressing multiple openssl CVEs

Note: CVE-2026-27171 (zlib) is covered by a separate PR (#244).

Related to tetrateio/tetrate#28867
Related to tetrateio/tetrate#28882
Related to tetrateio/tetrate#28883
Related to tetrateio/tetrate#28857
Related to tetrateio/tetrate#28893