### PR TITLE
cves: pin openssl/musl versions in Alpine runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ FROM alpine:3.23
 
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates
+    apk add --no-cache ca-certificates "libssl3>=3.3.7-r0" "libcrypto3>=3.3.7-r0" "musl>=1.2.5-r11"
 
 VOLUME /skywalking/configs
 


### PR DESCRIPTION
## Summary

This PR fixes multiple CVEs affecting the satellite Docker image's Alpine runtime layer.

After rebasing onto `main`, the prometheus bump and kubernetes_kinds.go changes were already merged via #246, and the Go toolchain is already at 1.26.2 in `main` (which covers the Go stdlib CVE). The only remaining net change is pinning the OpenSSL and musl versions.

| CVE | Severity | Component | Fix |
|-----|----------|-----------|-----|
| CVE-2026-28387 | LOW | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` |
| CVE-2026-31789 | LOW | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` |
| CVE-2026-28389 | MEDIUM | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` |
| CVE-2026-31790 | HIGH | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` |
| CVE-2026-28390 | LOW | openssl | Pin `libssl3>=3.3.7-r0` and `libcrypto3>=3.3.7-r0` |
| CVE-2026-40200 | HIGH | musl | Pin `musl>=1.2.5-r11` |
| CVE-2026-32288 | MEDIUM | stdlib (Go) | Already fixed: Go is at 1.26.2 in `main` |
| CVE-2026-40179 | MEDIUM | prometheus/prometheus | Already fixed: bumped via #246 |

## Changes

- **docker/Dockerfile**: Added explicit version pins `libssl3>=3.3.7-r0 libcrypto3>=3.3.7-r0 musl>=1.2.5-r11` to the `apk add` command in the alpine runtime stage

## Testing

- Build verified: `go build ./...` succeeded with no errors
- `gofmt` clean
- Docker image built locally and scanned with Trivy: **0 vulnerabilities** (all targeted CVEs absent)

Related to tetrateio/tetrate#29075
Related to tetrateio/tetrate#29102
Related to tetrateio/tetrate#29103
Related to tetrateio/tetrate#29118
Related to tetrateio/tetrate#29119
Related to tetrateio/tetrate#29121
Related to tetrateio/tetrate#29123
Related to tetrateio/tetrate#29126
Related to tetrateio/tetrate#29127
Related to tetrateio/tetrate#29130
Related to tetrateio/tetrate#29138
Related to tetrateio/tetrate#29151