### PR TITLE
cves: bump prometheus from v0.311.2 to v0.311.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
-	github.com/prometheus/prometheus v0.311.2
+	github.com/prometheus/prometheus v0.311.3
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.311.2 h1:6fBxp93y08GAZGNT1o3bIhgV/AMYvBFfU+ltDNEsHg8=
-github.com/prometheus/prometheus v0.311.2/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
+github.com/prometheus/prometheus v0.311.3 h1:3IrVxQv6v5i/ZCGi6OrYeBhtCwaPTn6Z3DYruXoYm3M=
+github.com/prometheus/prometheus v0.311.3/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=


### PR DESCRIPTION
## Summary

Upgrade `github.com/prometheus/prometheus` from `v0.311.2` to `v0.311.3` to fix the following CVEs:

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-42151 | HIGH | github.com/prometheus/prometheus | v0.311.2 → v0.311.3 |
| CVE-2026-42154 | HIGH | github.com/prometheus/prometheus | v0.311.2 → v0.311.3 |
| GHSA-fw8g-cg8f-9j28 | MEDIUM | github.com/prometheus/prometheus | v0.311.2 → v0.311.3 |

## Verification

A Docker image was built locally and scanned with Trivy — **0 vulnerabilities** detected (0 Critical, 0 High, 0 Medium, 0 Low).

## Notes

This fix addresses CVEs present in two satellite image tags used in the Tetrate monorepo:
- Tag `vd8151c147760e2993a4fd583af75c5821c126bb1` (used in master and release-1.14.x): prometheus was at v0.311.2
- Tag `vebc14e3c7f2cbfbcf16cb59d057df353675b1ea6` (used in release-1.11.x and release-1.12.x): prometheus was at v0.43.0, already upgraded to v0.311.2 in commit 02962f1

Both tags are on the same `main` branch lineage — this single PR fixes both by advancing to v0.311.3.

@kezhenxu94 Could you please review this PR?