### PR TITLE
cves: bump Go from 1.26.2 to 1.26.3 to fix stdlib CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.2 AS build
+FROM golang:1.26.3 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/skywalking-satellite
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/Shopify/sarama v1.27.2


### PR DESCRIPTION
## Summary

This PR bumps the Go toolchain from 1.26.2 to 1.26.3 to fix the following Go standard library CVEs:

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-39825 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-39836 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-42499 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-33811 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-39826 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-39820 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-33814 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |
| CVE-2026-39823 | High | stdlib (Go standard library) | Bump Go 1.26.2 → 1.26.3 |

## Changes

- `docker/Dockerfile`: Updated base image from `golang:1.26.2` to `golang:1.26.3`
- `go.mod`: Updated toolchain directive from `go1.26.2` to `go1.26.3`

## Verification

A local Docker image was built and scanned with Trivy — **0 vulnerabilities** detected after the upgrade.

@kezhenxu94