### PR TITLE
cves: bump go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/skywalking-satellite
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/Shopify/sarama v1.27.2


### PR DESCRIPTION
## CVEs addressed

Bump the Go toolchain from 1.26.3 to 1.26.4 to fix the following Go stdlib CVEs:

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| UNKNOWN | CVE-2026-42504 | stdlib | bumped Go toolchain 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-27145 | stdlib | bumped Go toolchain 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-42507 | stdlib | bumped Go toolchain 1.26.3 → 1.26.4 |

cc @kezhenxu94