### PR TITLE
cves: bump go to 1.26.4, openssl to 3.5.7-r0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3 AS build
+FROM golang:1.26.4 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH
@@ -30,7 +30,7 @@ RUN mv /src/bin/skywalking-satellite-${VERSION}-linux-${TARGETARCH} /src/bin/sky
 
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates "libssl3>=3.3.7-r0" "libcrypto3>=3.3.7-r0" "musl>=1.2.5-r11" && \
+RUN apk add --no-cache ca-certificates "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "musl>=1.2.5-r11" && \
     apk add --no-cache \
         --repository https://dl-cdn.alpinelinux.org/alpine/edge/main \
         "busybox>=1.37.0-r31" "busybox-binsh>=1.37.0-r31" "ssl_client>=1.37.0-r31"


### PR DESCRIPTION
## Summary

Fix multiple CVEs in the Docker image by updating the build toolchain and runtime OpenSSL libraries:

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| CVE-2026-45447 | HIGH | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-45445 | MEDIUM | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-34182 | MEDIUM | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42769 | MEDIUM | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-34181 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-34183 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42768 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42764 | MEDIUM | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-45446 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-7383 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42770 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-34180 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42767 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-9076 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42766 | LOW | openssl (Alpine) | libssl3/libcrypto3 ≥ 3.5.7-r0 |
| CVE-2026-42504 | HIGH | Go stdlib | golang:1.26.4 |
| CVE-2026-27145 | MEDIUM | Go stdlib | golang:1.26.4 |
| CVE-2026-42507 | MEDIUM | Go stdlib | golang:1.26.4 |

## Changes

- `docker/Dockerfile`: Bump build base image `golang:1.26.3` → `golang:1.26.4`
- `docker/Dockerfile`: Bump minimum OpenSSL library versions `libssl3>=3.3.7-r0` → `libssl3>=3.5.7-r0` and `libcrypto3>=3.3.7-r0` → `libcrypto3>=3.5.7-r0`

## Verification

Local trivy scan of the rebuilt image shows 0 CVEs (alpine OS: 0, gobinary: 0).

/cc @kezhenxu94