### PR TITLE
cves: bump libssl3 and libcrypto3 to 3.5.7-r0 to fix openssl CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN mv /src/bin/skywalking-satellite-${VERSION}-linux-${TARGETARCH} /src/bin/sky
 
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates "libssl3>=3.3.7-r0" "libcrypto3>=3.3.7-r0" "musl>=1.2.5-r11" && \
+RUN apk add --no-cache ca-certificates "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "musl>=1.2.5-r11" && \
     apk add --no-cache \
         --repository https://dl-cdn.alpinelinux.org/alpine/edge/main \
         "busybox>=1.37.0-r31" "busybox-binsh>=1.37.0-r31" "ssl_client>=1.37.0-r31"


### PR DESCRIPTION
## CVEs Fixed

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| CVE-2026-34183 | MEDIUM | libssl3, libcrypto3 | Bumped to >=3.5.7-r0 |
| CVE-2026-42769 | LOW | libssl3, libcrypto3 | Bumped to >=3.5.7-r0 |
| CVE-2026-34181 | LOW | libssl3, libcrypto3 | Bumped to >=3.5.7-r0 |
| CVE-2026-42768 | LOW | libssl3, libcrypto3 | Bumped to >=3.5.7-r0 |

These CVEs affect openssl/libssl3/libcrypto3 packages in Alpine 3.23. Fixed by bumping minimum version from 3.3.7-r0 to 3.5.7-r0.

/cc @kezhenxu94