### PR TITLE
build: bump go to 1.26 and golang base images to 1.26.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3 AS build
+FROM golang:1.26.4 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-satellite
 
-go 1.25.0
+go 1.26.0
 
 toolchain go1.26.4
 

--- a/test/e2e/base/satellite/Dockerfile
+++ b/test/e2e/base/satellite/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25
+FROM golang:1.26
 
 ADD . /satellite_code
 WORKDIR /satellite_code

--- a/test/e2e/base/satellite/Dockerfile
+++ b/test/e2e/base/satellite/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26
+FROM golang:1.26.4
 
 ADD . /satellite_code
 WORKDIR /satellite_code


### PR DESCRIPTION
## Summary

- Bump `go.mod` go directive from 1.25.0 to 1.26.0
- Bump `docker/Dockerfile` build image from `golang:1.26.3` to `golang:1.26.4`
- Bump `test/e2e/base/satellite/Dockerfile` from `golang:1.25` to `golang:1.26`

## Test plan

- CI build and e2e tests