### PR TITLE
cves: bump go to 1.26.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.4 AS build
+FROM golang:1.26.5 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/skywalking-satellite
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/Shopify/sarama v1.27.2


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.26.4 to 1.26.5 in `docker/Dockerfile` and the `toolchain` directive in `go.mod` to fix two Go stdlib CVEs.

## CVEs Fixed

| CVE ID | Severity | Fix |
|--------|----------|-----|
| CVE-2026-42505 | High | Upgrade Go 1.26.4 → 1.26.5 |
| CVE-2026-39822 | High | Upgrade Go 1.26.4 → 1.26.5 |

## Trivy Scan Results

Scanned locally built image — **0 High/Critical CVEs found**.

| CVE ID | Status |
|--------|--------|
| CVE-2026-42505 | ABSENT ✓ |
| CVE-2026-39822 | ABSENT ✓ |

@kezhenxu94 Please review.