### PR TITLE
cves: bump go to 1.26.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.5 AS build
+FROM golang:1.26.6 AS build
 
 ARG VERSION="latest"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/skywalking-satellite
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/Shopify/sarama v1.27.2


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.5 to 1.26.6 in `docker/Dockerfile` and the `toolchain` directive in `go.mod` to fix Go stdlib CVEs.

### CVEs fixed

| Severity | CVE | Package | Fix |
|---|---|---|---|
| — | CVE-2026-33818 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-39821 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-46600 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56853 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56858 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56859 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56860 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56862 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56864 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |
| — | CVE-2026-56865 | Go stdlib | Go toolchain 1.26.5 → 1.26.6 |

### Verification

- `go build ./...` and `go vet ./...` pass with Go 1.26.6.
- Docker image built locally from `docker/Dockerfile`; the resulting binary reports `go1.26.6` (`go version <binary>`).
- Image scanned: none of the CVEs above are present. The only remaining findings are three busybox CVEs (CVE-2026-38753/38754/38755) that have no fixed upstream version yet.

/cc @kezhenxu94