### PR TITLE
cves: bump libssl3/libcrypto3 to 3.5.8-r0 in Alpine Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN mv /src/bin/skywalking-satellite-${VERSION}-linux-${TARGETARCH} /src/bin/sky
 
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "musl>=1.2.5-r11" && \
+RUN apk add --no-cache ca-certificates "libssl3>=3.5.8-r0" "libcrypto3>=3.5.8-r0" "musl>=1.2.5-r11" && \
     apk add --no-cache \
         --repository https://dl-cdn.alpinelinux.org/alpine/edge/main \
         "busybox>=1.37.0-r31" "busybox-binsh>=1.37.0-r31" "ssl_client>=1.37.0-r31"


### PR DESCRIPTION
## Summary

Bump the minimum required versions of  and  in the Alpine-based Docker image from `3.5.7-r0` to `3.5.8-r0` to remediate three CVEs in the OpenSSL library.

| CVE | Severity | Fixed Version |
|-----|----------|---------------|
| CVE-2026-14456 | HIGH | libssl3/libcrypto3 3.5.8-r0 |
| CVE-2026-18798 | HIGH | libssl3/libcrypto3 3.5.8-r0 |
| CVE-2026-63075 | MEDIUM | libssl3/libcrypto3 3.5.8-r0 |

## Verification

Trivy scan of the locally built image with this change shows **0 Critical, 0 High, 0 Medium** vulnerabilities.

Related to tetrateio/tetrate#33863 Related to tetrateio/tetrate#33866 Related to tetrateio/tetrate#33876